### PR TITLE
Fix trpc connection + persistence

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -29,4 +29,4 @@ app.register(fastifyTRPCPlugin, {
   } satisfies FastifyTRPCPluginOptions<AppRouter>['trpcOptions'],
 });
 
-void app.listen({ port: parseInt(process.env.PORT ?? '') ?? 3000 });
+void app.listen({ port: parseInt(process.env.PORT || '') || 3000 });

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,0 +1,3 @@
+# Backend host
+# Will use http://localhost:3000 if unset
+VITE_BACKEND=http://localhost:3000

--- a/webapp/app/root.tsx
+++ b/webapp/app/root.tsx
@@ -6,8 +6,10 @@ import {
   Scripts,
   ScrollRestoration,
 } from "react-router";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { QueryClient } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import { useState } from "react";
 
@@ -56,20 +58,24 @@ function getQueryClient() {
   }
 }
 
+ const asyncStoragePersister = createAsyncStoragePersister({
+    storage: typeof window !== "undefined" ? window.localStorage : undefined
+  });
+
 export function Layout({ children }: { children: React.ReactNode }) {
     const queryClient = getQueryClient();
     const [trpcClient] = useState(() =>
       createTRPCClient<AppRouter>({
         links: [
           httpBatchLink({
-            url: "http://localhost:38565",
+            url: "http://localhost:3000/trpc",
           }),
         ],
       }),
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <PersistQueryClientProvider client={queryClient} persistOptions={{ persister: asyncStoragePersister }}>
       <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
         <html lang="en">
           <head>
@@ -86,7 +92,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         </html>
       </TRPCProvider>
       <ReactQueryDevtools />
-    </QueryClientProvider>
+    </PersistQueryClientProvider>
   );
 }
 

--- a/webapp/app/root.tsx
+++ b/webapp/app/root.tsx
@@ -68,7 +68,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       createTRPCClient<AppRouter>({
         links: [
           httpBatchLink({
-            url: "http://localhost:3000/trpc",
+            url: (import.meta.env.VITE_BACKEND || "http://localhost:3000") + "/trpc",
           }),
         ],
       }),


### PR DESCRIPTION
Sets up React Query asynchronous storage persister using `window.localStorage`. Also fixes the connection with tRPC as fastify wasn't adequately falling back to port `3000`.

Closes #17 