### PR TITLE
Generate PDF certificates with tRPC router

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,8 +22,8 @@
     "@node-rs/argon2": "^2.0.2",
     "@oslojs/encoding": "^1.1.0",
     "@react-pdf/renderer": "^4.3.1",
-    "@trpc/client": "^11.4.3",
-    "@trpc/server": "^11.4.3",
+    "@trpc/client": "^11.7.1",
+    "@trpc/server": "^11.7.1",
     "@types/pg": "^8.15.4",
     "@zxcvbn-ts/core": "^3.0.4",
     "@zxcvbn-ts/language-common": "^3.0.4",
@@ -37,6 +37,7 @@
     "nanoid": "^5.1.5",
     "nestjs-zod": "^4.3.1",
     "pg": "^8.16.0",
+    "react": "^19.2.0",
     "zod": "^3.25.74"
   },
   "devDependencies": {

--- a/backend/src/routers/certificate.tsx
+++ b/backend/src/routers/certificate.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { basicProcedure, router } from '../utils/trpc';
+import { pdf } from '@react-pdf/renderer';
+import z from 'zod';
+import { CertificateDocument } from '../pdf/pdf_template';
+import { eq } from 'drizzle-orm';
+
+export const certificateRouter = router({
+  generateCertificate: basicProcedure // Replace with protectedProcedure once auth works
+    .input(
+      z.object({
+        profileId: z.string(),
+        courseEventId: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const profile = await ctx.db.client.query.profile.findFirst({
+        where: eq(ctx.db.schema.profile.id, input.profileId),
+      });
+      const courseEvent = await ctx.db.client.query.courseEvent.findFirst({
+        where: eq(ctx.db.schema.courseEvent.id, input.courseEventId),
+      });
+
+      if (!profile) {
+        // No profile found
+        return null;
+      }
+
+      if (!courseEvent) {
+        // No course event found
+        return null;
+      }
+
+      const course = await ctx.db.client.query.course.findFirst({
+        where: eq(ctx.db.schema.course.id, courseEvent.courseId),
+      });
+
+      if (!course) {
+        // No course found
+        return null;
+      }
+
+      const name = `${profile.firstName} ${profile.lastName}`;
+
+      return {
+        blob: await pdf(
+          <CertificateDocument
+            name={name}
+            date={courseEvent?.classStartDatetime?.toDateString()}
+            course={courseEvent?.courseId}
+          />,
+        ).toBlob(),
+      };
+    }),
+});

--- a/backend/src/trpc.ts
+++ b/backend/src/trpc.ts
@@ -1,10 +1,12 @@
 import { adminRouter } from './routers/admin';
 import { authRouter } from './routers/auth';
+import { certificateRouter } from './routers/certificate';
 import { router } from './utils/trpc';
 
 export const appRouter = router({
   authRouter,
   adminRouter,
+  certificateRouter,
 });
 
 // Export type router type signature,

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "vrwa",
@@ -27,8 +28,8 @@
         "@node-rs/argon2": "^2.0.2",
         "@oslojs/encoding": "^1.1.0",
         "@react-pdf/renderer": "^4.3.1",
-        "@trpc/client": "^11.4.3",
-        "@trpc/server": "^11.4.3",
+        "@trpc/client": "^11.7.1",
+        "@trpc/server": "^11.7.1",
         "@types/pg": "^8.15.4",
         "@zxcvbn-ts/core": "^3.0.4",
         "@zxcvbn-ts/language-common": "^3.0.4",
@@ -42,6 +43,7 @@
         "nanoid": "^5.1.5",
         "nestjs-zod": "^4.3.1",
         "pg": "^8.16.0",
+        "react": "^19.2.0",
         "zod": "^3.25.74",
       },
       "devDependencies": {

--- a/webapp/app/root.tsx
+++ b/webapp/app/root.tsx
@@ -10,7 +10,7 @@ import { QueryClient } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
-import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { createTRPCClient, httpBatchStreamLink } from "@trpc/client";
 import { useState } from "react";
 
 import "./app.css";
@@ -67,7 +67,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
     const [trpcClient] = useState(() =>
       createTRPCClient<AppRouter>({
         links: [
-          httpBatchLink({
+          httpBatchStreamLink({
             url: (import.meta.env.VITE_BACKEND || "http://localhost:3000") + "/trpc",
           }),
         ],


### PR DESCRIPTION
Adds a router with a single procedure to generate a certificate and return the blob. Should be replaced with a `protectedProcedure` once auth works.

Closes #23 